### PR TITLE
Convert shutdown handles to futures

### DIFF
--- a/src/channels.rs
+++ b/src/channels.rs
@@ -49,7 +49,10 @@ impl<'s> fmt::Debug for DebugLiteral<'s> {
 }
 
 /// Wait for our [broadcast::Receiver] to get a message. We assume that effectively
-/// any return from the receiver is "good enough".
+/// any return from the receiver is "good enough". If an error occured, that usually
+/// means that someone tried to send something and we missed it (lag would be difficult
+/// to achieve here), or closed all of the senders, which is equivalent to dropping all
+/// of the senders and indicates that we'd probably like to shut down.
 async fn recv_once(mut rx: broadcast::Receiver<()>) {
     match rx.recv().await {
         Ok(()) => {


### PR DESCRIPTION
We can directly treat both Shutdown and ShutdownHandle as futures, since they can only be awaited succesfully
once. They are both cancel safe (i.e. we can stop awaiting them and then resume in the future), but it doesn't
make sense for them to do much besides wait for the shutdown signal.

This also makes the API a bit simpler, in that we don't need the .wait() method anywhere.