### PR TITLE
Fix waiting on signals

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 pin-project-lite = "^0.2.9"
-tokio = { version = "^1", features = ["sync", "signal"] }
+tokio = { version = "^1", features = ["sync", "signal", "macros"] }
 tracing = "^0.1"
 
 [dev-dependencies]


### PR DESCRIPTION
Properly wait for either ctrl-c or a shutdown signal from elsewhere.